### PR TITLE
Use nox

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -53,21 +53,8 @@ jobs:
       - name: Run Tests
         run: brownie test
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-      - name: Checkout PyTorch
-        uses: actions/checkout@master
-      - name: Install flake8
-        run: pip install flake8
-      - name: Run flake8
-        uses: suo/flake8-github-action@v1
-        with:
-          checkName: 'flake8'   # NOTE: this needs to be the same as the job name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install nox
+        run: python -m pip install nox
+
+      - name: Run nox
+        run: nox

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__
+.coverage
 .history
 .hypothesis/
+.tox
 build/
 reports/
 csv/

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,16 @@
+import nox
+
+
+@nox.session(python=['3.9'])
+def tests(session):
+    session.install('poetry')
+    session.run('poetry', 'install')
+    session.run('coverage', 'run', '-m', 'pytest')
+    session.run('coverage', 'report')
+
+
+@nox.session
+def lint(session):
+    session.install('poetry')
+    session.run('poetry', 'install')
+    session.run('flake8', 'scripts', 'tests')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,14 @@ schedule = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.2"
+coverage = "^5.5"
+nox = "^2021.6.12"
+
+[tool.coverage.run]
+omit = [".*", "*/site-packages/*", "*/tests*"]
+
+[tool.coverage.report]
+fail_under = 48
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- Use `nox` to run `flake8`, `pytest`, and `coverage`
- Use `nox` in GitHub Actions

In the interest of merging this PR the current coverage fail under is set to the current repo coverage of 48%.